### PR TITLE
chore: migrate to new github org name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Instructor Go is a library that makes it a breeze to work with structured output
 [![Twitter Follow](https://img.shields.io/twitter/follow/jxnlco?style=social)](https://twitter.com/jxnlco)
 [![LinkedIn Follow](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/robby-horvath/)
 [![Documentation](https://img.shields.io/badge/docs-available-brightgreen)](https://go.useinstructor.com)
-[![GitHub issues](https://img.shields.io/github/issues/instructor-ai/instructor-go.svg)](https://github.com/instructor-ai/instructor-go/issues)
+[![GitHub issues](https://img.shields.io/github/issues/567-labs/instructor-go.svg)](https://github.com/567-labs/instructor-go/issues)
 [![Discord](https://img.shields.io/discord/1192334452110659664?label=discord)](https://discord.gg/UD9GPjbs8c)
 
 Built on top of [`invopop/jsonschema`](https://github.com/invopop/jsonschema) and utilizing `jsonschema` Go struct tags (so no changing code logic), it provides a simple and user-friendly API to manage validation, retries, and streaming responses. Get ready to supercharge your LLM workflows!
@@ -17,15 +17,15 @@ Built on top of [`invopop/jsonschema`](https://github.com/invopop/jsonschema) an
 Install the package into your code with:
 
 ```bash
-go get "github.com/instructor-ai/instructor-go/pkg/instructor"
+go get "github.com/567-labs/instructor-go/pkg/instructor"
 ```
 
 Import in your code:
 
 ```go
 import (
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 ```
@@ -51,9 +51,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -226,8 +226,8 @@ Instructor Go provides a unified conversation history API that works across all 
 
 ```go
 import (
-    "github.com/instructor-ai/instructor-go/pkg/instructor/core"
-    instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+    "github.com/567-labs/instructor-go/pkg/instructor/core"
+    instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
     "github.com/sashabaranov/go-openai"
 )
 
@@ -287,10 +287,10 @@ The same conversation can be used across different providers using a consistent 
 
 ```go
 import (
-    instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
-    instructor_anthropic "github.com/instructor-ai/instructor-go/pkg/instructor/providers/anthropic"
-    instructor_google "github.com/instructor-ai/instructor-go/pkg/instructor/providers/google"
-    instructor_cohere "github.com/instructor-ai/instructor-go/pkg/instructor/providers/cohere"
+    instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
+    instructor_anthropic "github.com/567-labs/instructor-go/pkg/instructor/providers/anthropic"
+    instructor_google "github.com/567-labs/instructor-go/pkg/instructor/providers/google"
+    instructor_cohere "github.com/567-labs/instructor-go/pkg/instructor/providers/cohere"
 )
 
 // OpenAI

--- a/docs/conversation_history.md
+++ b/docs/conversation_history.md
@@ -11,7 +11,7 @@ Instead of manually managing provider-specific message arrays, you can use the `
 ### Creating a Conversation
 
 ```go
-import "github.com/instructor-ai/instructor-go/pkg/instructor/core"
+import "github.com/567-labs/instructor-go/pkg/instructor/core"
 
 // With a system prompt
 conversation := core.NewConversation("You are a helpful assistant")
@@ -61,7 +61,7 @@ conversation.ClearKeepingSystem()
 
 ```go
 import (
-    instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+    instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
     "github.com/sashabaranov/go-openai"
 )
 
@@ -83,7 +83,7 @@ resp, err := client.CreateChatCompletion(
 
 ```go
 import (
-    instructor_anthropic "github.com/instructor-ai/instructor-go/pkg/instructor/providers/anthropic"
+    instructor_anthropic "github.com/567-labs/instructor-go/pkg/instructor/providers/anthropic"
     "github.com/liushuangls/go-anthropic/v2"
 )
 
@@ -105,7 +105,7 @@ resp, err := client.CreateMessages(ctx, req, &response)
 ### Google (Gemini)
 
 ```go
-import instructor_google "github.com/instructor-ai/instructor-go/pkg/instructor/providers/google"
+import instructor_google "github.com/567-labs/instructor-go/pkg/instructor/providers/google"
 
 // Convert conversation to Google contents
 contents := instructor_google.ConversationToContents(conversation)
@@ -125,7 +125,7 @@ resp, err := client.CreateChatCompletion(
 
 ```go
 import (
-    instructor_cohere "github.com/instructor-ai/instructor-go/pkg/instructor/providers/cohere"
+    instructor_cohere "github.com/567-labs/instructor-go/pkg/instructor/providers/cohere"
     "github.com/cohere-ai/cohere-go/v2"
 )
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,3 +1,3 @@
 # Cookbook
 
-See [instructor-go/examples/](https://github.com/instructor-ai/instructor-go/tree/main/examples) for all examples.
+See [instructor-go/examples/](https://github.com/567-labs/instructor-go/tree/main/examples) for all examples.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ _Structured large language model (LLM) extraction in Go, designed for simplicity
 [![Twitter Follow](https://img.shields.io/twitter/follow/jxnlco?style=social)](https://twitter.com/jxnlco)
 [![LinkedIn Follow](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/robby-horvath/)
 [![Documentation](https://img.shields.io/badge/docs-available-brightgreen)](https://go.useinstructor.com)
-[![GitHub issues](https://img.shields.io/github/issues/instructor-ai/instructor-go.svg)](https://github.com/instructor-ai/instructor-go/issues)
+[![GitHub issues](https://img.shields.io/github/issues/567-labs/instructor-go.svg)](https://github.com/567-labs/instructor-go/issues)
 [![Discord](https://img.shields.io/discord/1192334452110659664?label=discord)](https://discord.gg/UD9GPjbs8c)
 
 Check us out in [Python](https://python.useinstructor.com/), [JS/TS](https://js.useinstructor.com/), [Elixir](https://github.com/thmsmlr/instructor_ex/) and [PHP](https://github.com/cognesy/instructor-php/).
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -74,7 +74,7 @@ Age:  %d
 
 ## Contributing
 
-If you want to help out, checkout some of the issues marked as `good-first-issue` or `help-wanted`. Found [here](https://github.com/instructor-ai/instructor-go/labels/good%20first%20issue). They could be anything from code improvements, a guest blog post, or a new cook book.
+If you want to help out, checkout some of the issues marked as `good-first-issue` or `help-wanted`. Found [here](https://github.com/567-labs/instructor-go/labels/good%20first%20issue). They could be anything from code improvements, a guest blog post, or a new cook book.
 
 ## License
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -17,7 +17,7 @@ and
   {% include ".icons/fontawesome/solid/star.svg" %}
 </span>
 us on
-<a href="https://www.github.com/instructor-ai/instructor-go">
+<a href="https://www.github.com/567-labs/instructor-go">
   <span class="twemoji github">
     {% include ".icons/fontawesome/brands/github.svg" %}
   </span>

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -105,7 +105,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	anthropic "github.com/liushuangls/go-anthropic/v2"
 )
 
@@ -190,7 +190,7 @@ func assert(condition bool, message string) {
 <details>
 <summary>Images with OpenAI</summary>
 
-![List of books](https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/openai/books.png)
+![List of books](https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/openai/books.png)
 
 Running
 
@@ -207,7 +207,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -238,7 +238,7 @@ func main() {
 		instructor.WithMaxRetries(3),
 	)
 
-	url := "https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/openai/books.png"
+	url := "https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/openai/books.png"
 
 	var bookCatalog BookCatalog
 	_, err := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
@@ -326,7 +326,7 @@ func main() {
 <details>
 <summary>Images with Anthropic</summary>
 
-![List of movies](https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/anthropic/movies.png)
+![List of movies](https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/anthropic/movies.png)
 
 Running
 
@@ -346,7 +346,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	"github.com/liushuangls/go-anthropic/v2"
 )
 
@@ -379,7 +379,7 @@ func main() {
 		instructor.WithMaxRetries(3),
 	)
 
-	url := "https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/anthropic/movies.jpg"
+	url := "https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/anthropic/movies.jpg"
 	data, err := urlToBase64(url)
 	if err != nil {
 		panic(err)
@@ -509,7 +509,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -656,7 +656,7 @@ import (
 
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	cohereclient "github.com/cohere-ai/cohere-go/v2/client"
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 )
 
 type Section struct {
@@ -812,7 +812,7 @@ import (
 
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	cohereclient "github.com/cohere-ai/cohere-go/v2/client"
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 )
 
 type HistoricalFact struct {
@@ -898,7 +898,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -969,8 +969,8 @@ func main() {
 <summary>Receipt Item Extraction from Image (using OpenAI GPT-4o)</summary>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/receipt/supermarket-receipt-template.jpg" alt="Receipt 1" width="45%">
-  <img src="https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/receipt/receipt-ocr-original.jpg" alt="Receipt 2" width="45%">
+  <img src="https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/receipt/supermarket-receipt-template.jpg" alt="Receipt 1" width="45%">
+  <img src="https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/receipt/receipt-ocr-original.jpg" alt="Receipt 2" width="45%">
 </p>
 
 Running
@@ -988,7 +988,7 @@ import (
 	"math"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -1163,7 +1163,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -1326,7 +1326,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	"google.golang.org/genai"
 )
 

--- a/examples/agent/main.go
+++ b/examples/agent/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/auto_ticketer/main.go
+++ b/examples/auto_ticketer/main.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/classification/main.go
+++ b/examples/classification/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_anthropic "github.com/instructor-ai/instructor-go/pkg/instructor/providers/anthropic"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_anthropic "github.com/567-labs/instructor-go/pkg/instructor/providers/anthropic"
 	"github.com/liushuangls/go-anthropic/v2"
 )
 

--- a/examples/document_segmentation/main.go
+++ b/examples/document_segmentation/main.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_cohere "github.com/567-labs/instructor-go/pkg/instructor/providers/cohere"
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	cohereclient "github.com/cohere-ai/cohere-go/v2/client"
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_cohere "github.com/instructor-ai/instructor-go/pkg/instructor/providers/cohere"
 )
 
 type Section struct {

--- a/examples/function_calling/main.go
+++ b/examples/function_calling/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/gemini/main.go
+++ b/examples/gemini/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	"google.golang.org/genai"
 )
 

--- a/examples/ollama/main.go
+++ b/examples/ollama/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/streaming/cohere/main.go
+++ b/examples/streaming/cohere/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	cohereclient "github.com/cohere-ai/cohere-go/v2/client"
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
 )
 
 type HistoricalFact struct {

--- a/examples/streaming/openai/main.go
+++ b/examples/streaming/openai/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/union/main.go
+++ b/examples/union/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/user/main.go
+++ b/examples/user/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/validator/main.go
+++ b/examples/validator/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 

--- a/examples/vision/anthropic/main.go
+++ b/examples/vision/anthropic/main.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor"
 	"github.com/liushuangls/go-anthropic/v2"
 )
 
@@ -41,7 +41,7 @@ func main() {
 		instructor.WithMaxRetries(3),
 	)
 
-	url := "https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/anthropic/movies.jpg"
+	url := "https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/anthropic/movies.jpg"
 	data, err := urlToBase64(url)
 	if err != nil {
 		panic(err)

--- a/examples/vision/openai/main.go
+++ b/examples/vision/openai/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -38,7 +38,7 @@ func main() {
 		instructor.WithMaxRetries(3),
 	)
 
-	url := "https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/openai/books.png"
+	url := "https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/openai/books.png"
 
 	conversation := core.NewConversation()
 	conversation.AddUserMessageWithImageURLs("Extract book catalog from the image", url)

--- a/examples/vision/receipt/README.md
+++ b/examples/vision/receipt/README.md
@@ -1,6 +1,6 @@
 # Receipt Image Extractor
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/receipt/supermarket-receipt-template.jpg" alt="Receipt 1" width="45%">
-  <img src="https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/receipt/receipt-ocr-original.jpg" alt="Receipt 2" width="45%">
+  <img src="https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/receipt/supermarket-receipt-template.jpg" alt="Receipt 1" width="45%">
+  <img src="https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/receipt/receipt-ocr-original.jpg" alt="Receipt 2" width="45%">
 </p>

--- a/examples/vision/receipt/main.go
+++ b/examples/vision/receipt/main.go
@@ -6,9 +6,9 @@ import (
 	"math"
 	"os"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	instructor_openai "github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	instructor_openai "github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -86,9 +86,9 @@ func main() {
 
 	urls := []string{
 		// source: https://templates.mediamodifier.com/645124ff36ed2f5227cbf871/supermarket-receipt-template.jpg
-		"https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/receipt/supermarket-receipt-template.jpg",
+		"https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/receipt/supermarket-receipt-template.jpg",
 		// source: https://ocr.space/Content/Images/receipt-ocr-original.jpg
-		"https://raw.githubusercontent.com/instructor-ai/instructor-go/main/examples/vision/receipt/receipt-ocr-original.jpg",
+		"https://raw.githubusercontent.com/567-labs/instructor-go/main/examples/vision/receipt/receipt-ocr-original.jpg",
 	}
 
 	for _, url := range urls {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/instructor-ai/instructor-go
+module github.com/567-labs/instructor-go
 
 go 1.23.0
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,7 @@ markdown_extensions:
   - pymdownx.magiclink:
       normalize_issue_symbols: true
       repo_url_shorthand: true
-      user: instructor-ai
+      user: 567-labs
       repo: instructor-go
   - pymdownx.mark
   - pymdownx.smartsymbols

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Instructor (Go)
 site_author: Jason Liu
 site_description: Structured LLM outputs for Go
 repo_name: instructor-go
-repo_url: https://github.com/instructor-ai/instructor-go
+repo_url: https://github.com/567-labs/instructor-go
 site_url: https://go.useinstructor.com/
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2024 Jason Liu

--- a/pkg/instructor/instructor.go
+++ b/pkg/instructor/instructor.go
@@ -1,11 +1,11 @@
 package instructor
 
 import (
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/providers/anthropic"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/providers/cohere"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/providers/google"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/providers/openai"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/providers/anthropic"
+	"github.com/567-labs/instructor-go/pkg/instructor/providers/cohere"
+	"github.com/567-labs/instructor-go/pkg/instructor/providers/google"
+	"github.com/567-labs/instructor-go/pkg/instructor/providers/openai"
 
 	cohereSDK "github.com/cohere-ai/cohere-go/v2/client"
 	anthropicSDK "github.com/liushuangls/go-anthropic/v2"

--- a/pkg/instructor/providers/anthropic/chat.go
+++ b/pkg/instructor/providers/anthropic/chat.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	anthropic "github.com/liushuangls/go-anthropic/v2"
 )
 

--- a/pkg/instructor/providers/anthropic/chat_stream.go
+++ b/pkg/instructor/providers/anthropic/chat_stream.go
@@ -3,7 +3,7 @@ package anthropic
 import (
 	"context"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 )
 
 func (i *InstructorAnthropic) InternalChatStream(ctx context.Context, request interface{}, schema *core.Schema) (<-chan string, error) {

--- a/pkg/instructor/providers/anthropic/client.go
+++ b/pkg/instructor/providers/anthropic/client.go
@@ -3,7 +3,7 @@ package anthropic
 import (
 	anthropic "github.com/liushuangls/go-anthropic/v2"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 )
 
 type InstructorAnthropic struct {

--- a/pkg/instructor/providers/anthropic/conversation.go
+++ b/pkg/instructor/providers/anthropic/conversation.go
@@ -1,7 +1,7 @@
 package anthropic
 
 import (
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	anthropic "github.com/liushuangls/go-anthropic/v2"
 )
 

--- a/pkg/instructor/providers/anthropic/conversation_test.go
+++ b/pkg/instructor/providers/anthropic/conversation_test.go
@@ -3,7 +3,7 @@ package anthropic
 import (
 	"testing"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	anthropic "github.com/liushuangls/go-anthropic/v2"
 )
 

--- a/pkg/instructor/providers/cohere/chat.go
+++ b/pkg/instructor/providers/cohere/chat.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	option "github.com/cohere-ai/cohere-go/v2/option"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
 )
 
 // Chat provides the public API that matches the original signature

--- a/pkg/instructor/providers/cohere/chat_stream.go
+++ b/pkg/instructor/providers/cohere/chat_stream.go
@@ -9,7 +9,7 @@ import (
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	option "github.com/cohere-ai/cohere-go/v2/option"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 )
 
 // ChatStream provides the public API that matches the original signature

--- a/pkg/instructor/providers/cohere/client.go
+++ b/pkg/instructor/providers/cohere/client.go
@@ -1,8 +1,8 @@
 package cohere
 
 import (
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	cohere "github.com/cohere-ai/cohere-go/v2/client"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
 )
 
 type InstructorCohere struct {

--- a/pkg/instructor/providers/cohere/conversation.go
+++ b/pkg/instructor/providers/cohere/conversation.go
@@ -1,8 +1,8 @@
 package cohere
 
 import (
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	cohere "github.com/cohere-ai/cohere-go/v2"
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
 )
 
 // ToCohereMessages converts unified conversation messages to Cohere format

--- a/pkg/instructor/providers/google/chat.go
+++ b/pkg/instructor/providers/google/chat.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	"google.golang.org/genai"
 )
 

--- a/pkg/instructor/providers/google/chat_stream.go
+++ b/pkg/instructor/providers/google/chat_stream.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	"google.golang.org/genai"
 )
 

--- a/pkg/instructor/providers/google/client.go
+++ b/pkg/instructor/providers/google/client.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	"google.golang.org/genai"
 )
 

--- a/pkg/instructor/providers/google/conversation.go
+++ b/pkg/instructor/providers/google/conversation.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	"google.golang.org/genai"
 )
 

--- a/pkg/instructor/providers/openai/chat.go
+++ b/pkg/instructor/providers/openai/chat.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	"github.com/invopop/jsonschema"
 	openai "github.com/sashabaranov/go-openai"
 )

--- a/pkg/instructor/providers/openai/chat_stream.go
+++ b/pkg/instructor/providers/openai/chat_stream.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	openai "github.com/sashabaranov/go-openai"
 )
 

--- a/pkg/instructor/providers/openai/client.go
+++ b/pkg/instructor/providers/openai/client.go
@@ -1,7 +1,7 @@
 package openai
 
 import (
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	openai "github.com/sashabaranov/go-openai"
 )
 

--- a/pkg/instructor/providers/openai/conversation.go
+++ b/pkg/instructor/providers/openai/conversation.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"encoding/base64"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	openai "github.com/sashabaranov/go-openai"
 )
 

--- a/pkg/instructor/providers/openai/conversation_test.go
+++ b/pkg/instructor/providers/openai/conversation_test.go
@@ -3,7 +3,7 @@ package openai
 import (
 	"testing"
 
-	"github.com/instructor-ai/instructor-go/pkg/instructor/core"
+	"github.com/567-labs/instructor-go/pkg/instructor/core"
 	openai "github.com/sashabaranov/go-openai"
 )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Migrate GitHub organization name from `instructor-ai` to `567-labs` across codebase and documentation.
> 
>   - **Imports and URLs**:
>     - Update import paths from `github.com/instructor-ai/instructor-go` to `github.com/567-labs/instructor-go` in all Go files.
>     - Update GitHub URLs in `README.md`, `docs/index.md`, `docs/examples/index.md`, `mkdocs.yml`, and `docs/overrides/main.html` to reflect the new organization name `567-labs`.
>   - **Documentation**:
>     - Update badges and links in `README.md` and `docs/index.md` to point to the new GitHub organization.
>     - Update image URLs in `examples/vision/receipt/README.md` and other example files to use the new organization path.
>   - **Configuration**:
>     - Change `module` path in `go.mod` to `github.com/567-labs/instructor-go`.
>     - Update `repo_url` in `mkdocs.yml` to `https://github.com/567-labs/instructor-go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor-go&utm_source=github&utm_medium=referral)<sup> for 63281a1b5739438bba14b7d5106da0eaa62a1937. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->